### PR TITLE
Adding timezone file for OracleLinux.

### DIFF
--- a/templates/timezone-OracleLinux
+++ b/templates/timezone-OracleLinux
@@ -1,0 +1,5 @@
+# File managed by Puppet
+
+ZONE="<%= @timezone %>"
+UTC=<%= @hw_utc %>
+ARC=false


### PR DESCRIPTION
Just copied the template from the RedHat version.  The params.pp file already has a matcher that catches OracleLinux's OS fact.
