### PR TITLE
add wheel to config_file_group

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,8 @@ class timezone::params {
   }
 
   $config_file_group = $::operatingsystem ? {
-    default => 'root',
+    'FreeBSD' => 'wheel',
+    default   => 'root',
   }
 
   $source = ''


### PR DESCRIPTION
config_file_group for $::osfamily FreeBSD is wheel, not root.  updated params.pp to reflect that.
