### PR TITLE
Fixup OS detection on timezone command for RHEL family platforms

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class timezone(
   $bool_audit_only=any2bool($audit_only)
   $bool_noops=any2bool($noops)
 
-  if $::operatingsystem =~ /(?i:RedHat|Centos)/ {
+  if $::operatingsystem =~ /(?i:RedHat|Centos|Scientific|Fedora|Amazon|Linux)/ {
     $rh_command = $::operatingsystemmajrelease ? {
       /7/     => "timedatectl set-timezone ${timezone}",
       default => 'tzdata-update',


### PR DESCRIPTION
Attempted to apply module on Scientific Linux 7 system and received:
```
Info: /Stage[main]/Timezone/File[timezone]: Scheduling refresh of Exec[set-timezone]
Error: /Stage[main]/Timezone/Exec[set-timezone]: Failed to call refresh: Could not find command 'set-timezone'
Error: /Stage[main]/Timezone/Exec[set-timezone]: Could not find command 'set-timezone'
```
This PR should match up the RHEL family platforms to what's coded later in the module.