### PR TITLE
added missing my_class var to params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,8 @@ class timezone::params {
   # This is calculated in timezone class
   $set_timezone_command = ''
 
+  $my_class = ''
+
   $config_file = $::operatingsystem ? {
     /(?i:RedHat|Centos|Scientific|Fedora|Amazon|Linux)/ => '/etc/sysconfig/clock',
     /(?i:Ubuntu|Debian|Mint)/                           => '/etc/timezone',


### PR DESCRIPTION
This is a simple addition of the missing `my_class = ''` to params.pp in order to resolve #14.
