### PR TITLE
added missing custom class support to init.pp, added spec tests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,11 @@ class timezone(
     default => $set_timezone_command,
   }
 
+  ### Include custom class if $my_class is set
+  if $timezone::my_class and $timezone::my_class != '' {
+    include $timezone::my_class
+  }
+
   $manage_audit = $timezone::bool_audit_only ? {
     true  => 'all',
     false => undef,

--- a/manifests/spec.pp
+++ b/manifests/spec.pp
@@ -1,0 +1,22 @@
+# Class: timezone::spec
+#
+# This class is used only for rpsec-puppet tests
+# Can be taken as an example on how to do custom classes but should not
+# be modified.
+#
+# == Usage
+#
+# This class is not intended to be used directly.
+# Use it as reference
+#
+class timezone::spec inherits timezone {
+
+  # This just a test to override the arguments of an existing resource
+  # Note that you can achieve this same result with just:
+  # class { "timezone": template => "timezone/spec.erb" }
+
+  File['timezone'] {
+    content => template('timezone/spec.erb'),
+  }
+
+}

--- a/spec/classes/timezone_spec.rb
+++ b/spec/classes/timezone_spec.rb
@@ -15,4 +15,13 @@ describe 'timezone' do
 
   it { should compile }
   it { should contain_class('timezone') }
+
+  describe 'Test customizations - custom class' do
+    let(:params) { {:my_class => "timezone::spec" } }
+    it 'should automatically include a custom class' do
+      content = catalogue.resource('file', 'timezone').send(:parameters)[:content]
+      content.should match "fqdn: rspec.example42.com"
+    end
+  end
+
 end

--- a/templates/spec.erb
+++ b/templates/spec.erb
@@ -1,0 +1,8 @@
+# This is a template used only for rspec tests
+
+# Yaml of the whole scope
+<%= scope.to_hash.reject { |k,v| !( k.is_a?(String) && v.is_a?(String) ) }.to_yaml %>
+
+# Custom Options
+<%= @options['opt_a'] %>
+<%= @options['opt_b'] %>


### PR DESCRIPTION
A colleague pointed out that I forgot to actually enable use of the my_class support in #15, so here's an additional PR with the init.pp support.

Also included the related rspec magic based off some of your other modules (openssh / vsftpd).