### PR TITLE
added support for ubuntu 16.04

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,17 +75,24 @@ class timezone(
   $bool_audit_only=any2bool($audit_only)
   $bool_noops=any2bool($noops)
 
-  if $::operatingsystem =~ /(?i:RedHat|Centos|Scientific|Fedora|Amazon|Linux)/ {
-    $rh_command = $::operatingsystemmajrelease ? {
-      /7/     => "timedatectl set-timezone ${timezone}",
-      default => 'tzdata-update',
+  case $osfamily {
+    'RedHat' : {
+      $tz_command = $::operatingsystemmajrelease ? {
+        /7/     => "timedatectl set-timezone ${timezone}",
+        default => 'tzdata-update',
+      }
+    'Debian' : {
+      $tz_command = $::operatingsystemmajrelease ? {
+        /16.04/ => "timedatectl set-timezone ${timezone}",
+        default => 'dpkg-reconfigure -f noninteractive tzdata',
+      }
     }
   }
 
   $real_set_timezone_command = $set_timezone_command ? {
     ''      => $::operatingsystem ? {
-      /(?i:RedHat|Centos|Scientific|Fedora|Amazon|Linux)/ => $rh_command,
-      /(?i:Ubuntu|Debian|Mint)/                           => 'dpkg-reconfigure -f noninteractive tzdata',
+      /(?i:RedHat|Centos|Scientific|Fedora|Amazon|Linux)/ => $tz_command,
+      /(?i:Ubuntu|Debian|Mint)/                           => $tz_command,
       /(?i:SLES|OpenSuSE)/                                => "zic -l ${timezone}",
       /(?i:OpenBSD)/                                      => "ln -fs /usr/share/zoneinfo/${timezone} /etc/localtime",
       /(?i:FreeBSD)/                                      => "cp /usr/share/zoneinfo/${timezone} /etc/localtime && adjkerntz -a",


### PR DESCRIPTION
Looks like it has no affect on 16.04, since it has moved into timedatectl
```
root@build-xenial:~# cat /etc/timezone
Europe/Copenhagen
root@build-xenial:~# /usr/sbin/dpkg-reconfigure -f noninteractive tzdata

Current default time zone: 'Indian/Antananarivo'
Local time is now:      Wed Aug  3 09:05:49 EAT 2016.
Universal Time is now:  Wed Aug  3 06:05:49 UTC 2016.

root@build-xenial:~# date
Wed Aug  3 09:05:53 EAT 2016
root@build-xenial:~# cat /etc/timezone
Indian/Antananarivo
```