### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@ class timezone(
       /(?i:Ubuntu|Debian|Mint)/                           => $debian_command,
       /(?i:SLES|OpenSuSE)/                                => "zic -l ${timezone}",
       /(?i:OpenBSD)/                                      => "ln -fs /usr/share/zoneinfo/${timezone} /etc/localtime",
-      /(?i:FreeBSD)/                                      => "cp /usr/share/zoneinfo/${timezone} /etc/localtime && adjkerntz -a",
+      /(?i:FreeBSD)/                                      => "ln -sf /usr/share/zoneinfo/${timezone} /etc/localtime && adjkerntz -a",
       /(?i:Solaris)/                                      => "rtc -z ${timezone} && rtc -c",
     },
     default => $set_timezone_command,


### PR DESCRIPTION
To fix issues with the actual FreeBSD releases:
# ls -laF /etc/localtime                                                                                                                                                                                       
lrwxr-xr-x  1 root  wheel  23 Feb  2  2016 /etc/localtime@ -> /usr/share/zoneinfo/UTC
# cp /usr/share/zoneinfo/UTC /etc/localtime                                            
cp: /etc/localtime and /usr/share/zoneinfo/UTC are identical (not copied).
# ln -s /usr/share/zoneinfo/UTC /etc/localtime                                         
ln: /etc/localtime: File exists


